### PR TITLE
service file: LimitNoFile raised to 65k

### DIFF
--- a/SOURCES/solr.service.in
+++ b/SOURCES/solr.service.in
@@ -8,7 +8,7 @@ EnvironmentFile=/etc/sysconfig/solr
 User=solr
 ExecStart=@@PKG_ROOT@@/bin/solr start -noprompt -h ${SOLR_HOSTNAME} -p ${SOLR_PORT} -z ${SOLR_ZK_STRING} -m ${SOLR_MEMORY} -a "${SOLR_JVM_OPTS}"
 ExecStop=@@PKG_ROOT@@/bin/solr stop
-LimitNOFILE=10000
+LimitNOFILE=65000
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Recommended by at least one major app user, NoFile limit should be raised to 65k. I don't know if this is really necessary, but it's unlikely to be harmful. See https://underyx.me/2015/05/18/raising-the-maximum-number-of-file-descriptors and https://stackoverflow.com/questions/21591535/is-there-any-downside-to-setting-ulimit-really-high